### PR TITLE
Theme Configuration

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,10 +1,11 @@
 import { StatusBar } from "expo-status-bar";
-import { StyleSheet, Button, Text, View } from "react-native";
+import { Button, Text, View } from "react-native";
 import { FIREBASE_DB } from "./firebaseConfig";
 import { addDoc, collection, getDocs } from "firebase/firestore";
 import react, { useEffect, useState, useCallback } from "react";
 import * as SplashScreen from 'expo-splash-screen';
-
+import { globalStyles } from "./constants/styles/global";
+import { themeCustomHook } from './custom/ThemeCustomHook'
 
 
 SplashScreen.preventAutoHideAsync();
@@ -13,6 +14,8 @@ SplashScreen.preventAutoHideAsync();
 export default function App() {
   const [testState, setTestState] = useState<any[]>([]);
   const [appIsReady, setAppIsReady] = useState<Boolean>(false);
+
+  const { themeTextStyle, themeContainerStyle } = themeCustomHook();
 
   async function testWriteToDB() {
     const newDoc = await addDoc(collection(FIREBASE_DB, "testCollection"), {
@@ -55,13 +58,13 @@ export default function App() {
   }
 
   return (
-    <View style={styles.container} onLayout={onLayoutRootView}>
+    <View style={[globalStyles.container, themeContainerStyle]} onLayout={onLayoutRootView}>
       <Button onPress={testWriteToDB} title="Test to write to DB" />
       {testState.length > 0 &&
         testState.map(
           (doc: { id: react.Key | null | undefined; title: any }) => (
             <View key={doc.id}>
-              <Text>{`Title: ${doc.title}`}</Text>
+              <Text style={[globalStyles.text, themeTextStyle]}>{`Title: ${doc.title}`}</Text>
             </View>
           )
         )}
@@ -69,12 +72,3 @@ export default function App() {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});

--- a/app/app.json
+++ b/app/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/app/constants/styles/global.ts
+++ b/app/constants/styles/global.ts
@@ -1,0 +1,29 @@
+import { StyleSheet} from "react-native";
+
+export const globalStyles  = StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+
+    text: {
+        fontSize: 15,
+    },
+
+    lightContainer: {
+        backgroundColor: '#ffffff',
+    },
+
+    darkContainer: {
+        backgroundColor: '#242c40',
+    },
+
+    lightThemeText: {
+        color: '#242c40',
+    },
+
+    darkThemeText: {
+        color: '#d0d0c0',
+    }
+})

--- a/app/custom/ThemeCustomHook.ts
+++ b/app/custom/ThemeCustomHook.ts
@@ -1,0 +1,16 @@
+import { useColorScheme, TextStyle, ViewStyle } from 'react-native';
+import { globalStyles } from '../constants/styles/global';
+
+interface ThemeStyles {
+  themeTextStyle: TextStyle;
+  themeContainerStyle: ViewStyle;
+}
+
+export const themeCustomHook = (): ThemeStyles => {
+  const colorScheme = useColorScheme();
+
+  const themeTextStyle: TextStyle = colorScheme === 'light' ? globalStyles.lightThemeText : globalStyles.darkThemeText;
+  const themeContainerStyle: ViewStyle = colorScheme === 'light' ? globalStyles.lightContainer : globalStyles.darkContainer;
+
+  return { themeTextStyle, themeContainerStyle };
+};


### PR DESCRIPTION
This PR adds the automatic theme functionality, using the Expo document. After this is merged, the theme of the app will change based on the theme of the native OS.


In addition, a global style file was added, which will keep things much cleaner. We will have to decide on some naming conventions for the styles that will be added to this file to avoid conflicts. 

Plus, this PR adds a custom hook to find the theme, instead of calling `useColorScheme` in every file.

**NOTE**: using a `ThemeProvider` is NOT feasible in this case, since Expo directly handles the theming, we just need to keep track of it in our global/local styling. 


**NOTE**:  the custom hook will be changed later so we can generalize dark/light themes

Example:


https://github.com/SENG480a-NutriDine/mobile/assets/83256092/f1c9c0a0-2b2d-4fb7-8653-8e89dd451cf9


